### PR TITLE
Fix Flask error with multiple wrappings

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -5,6 +5,7 @@
 
 
 import random
+from functools import wraps
 from socket import socket, AF_INET, SOCK_DGRAM
 import time
 import logging
@@ -154,6 +155,7 @@ class StatsdTimer(object):
     @staticmethod
     def wrap(bucket):
         def wrapper(func):
+            @wraps(func)
             def f(*args, **kw):
                 with StatsdTimer(bucket):
                     return func(*args, **kw)


### PR DESCRIPTION
When the `wrap` method is used around several Flask routes, the following error is generated:
```
Traceback (most recent call last):
  File "server.py", line 104, in <module>
    @statsd.StatsdTimer.wrap('health_GET')
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1097, in decorator
    self.add_url_rule(rule, endpoint, f, **options)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 65, in wrapper_func
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1068, in add_url_rule
    'existing endpoint function: %s' % endpoint)
AssertionError: View function mapping is overwriting an existing endpoint function: f
```

According to http://flask.pocoo.org/docs/0.11/patterns/viewdecorators/, the `functools.wraps()` method should be used to avoid this problem.

This PR fixes just that ;-)